### PR TITLE
[enhancement] Add missing bower.json.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,12 @@
+{
+  "name": "jquery-zclip",
+  "description": "JQuery wrapper library for ZeroClipboard. Provides an easy way to copy text to the clipboard using an invisible Adobe Flash movie and a jQuery interface.",
+  "version": "1.1.4",
+  "main": ["./jquery.zclip.js", "./ZeroClipboard.swf"],
+  "keywords": ["flash","clipboard","copy","cut","paste","zclip","clip","clippy", "zeroclipboard", "jquery"],
+  "license": "http://www.opensource.org/licenses/mit-license.php",
+  "authors": [{"name":"SteamDev","url":"http://www.steamdev.com/zclip/"},{"name":"Patrick Lodder","url":"https://github.com/patricklodder"}],
+  "homepage": "https://github.com/patricklodder/jquery-zclip",
+  "repository": {"type":"git","url":"https://github.com/patricklodder/jquery-zclip.git"},
+  "location": "git://github.com/patricklodder/jquery-zclip.git"
+}


### PR DESCRIPTION
#### Hey, maintainer(s) of patricklodder/jquery-zclip!

We at VersionEye are working hard to keep up the quality of the bower's registry.

We just finished our initial analysis of the quality of the Bower.io registry:

**7530** - registered packages, _224_ of them doesnt exists anymore;

We analysed **7306**  existing packages and  **1070** of them don't have bower.json on the master branch ( _that's where a Bower client pulls a data_ ).

Sadly, your library `patricklodder/jquery-zclip` is one of them.

Can you spare **15** minutes to help us to make Bower better?

Just add a new file `bower.json` and  change attributes.

```
{
  "name": "patricklodder/jquery-zclip",
  "version": "1.0.0",
  "main": "path/to/main.css",
  "description": "please add it",
  "license": "Eclipse",
  "ignore": [
    ".jshintrc",
    "**/*.txt"
  ],
  "dependencies": {
    "<dependency_name>": "<semantic_version>",
    "<dependency_name>": "<Local_folder>",
    "<dependency_name>": "<package>"
  },
  "devDependencies": {
    "<test-framework-name>": "<version>"
  }
}

```

Read more about bower.json [on the official spefication](http://bower.io/#defining-a-package) and nodejs [semver](https://github.com/isaacs/node-semver#ranges) library has great examples of proper versioning.

**NB!** Please _validate_ your bower.json with _jsonlint_ before commiting your updates.

Thank you!
